### PR TITLE
CLEANUP: ebmbtree: Replace always-taken elseif by else

### DIFF
--- a/ebmbtree.h
+++ b/ebmbtree.h
@@ -359,7 +359,7 @@ __ebmb_insert(struct eb_root *root, struct ebmb_node *new, unsigned int len)
 		new->node.leaf_p = new_rght;
 		*up_ptr = new_left;
 	}
-	else if (diff < 0) {
+	else {
 		new->node.branches.b[EB_LEFT] = new_leaf;
 		new->node.branches.b[EB_RGHT] = troot;
 		new->node.leaf_p = new_left;


### PR DESCRIPTION
`diff` is guaranteed to be less than 0, because the `if` handles the `>= 0`
case.

Found using GitHub's CodeQL scan in HAProxy's codebase.