### PR TITLE
Minor build fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 OBJS = ebtree.o eb32tree.o eb64tree.o ebmbtree.o ebsttree.o ebimtree.o ebistree.o
-CFLAGS = -O3 -W -Wall -Wdeclaration-after-statement
+CFLAGS = -O3 -W -Wall -Wextra -Wundef -Wdeclaration-after-statement -Wno-address-of-packed-member
 EXAMPLES = $(basename $(wildcard examples/*.c))
 
 all: libebtree.a

--- a/compiler.h
+++ b/compiler.h
@@ -40,38 +40,6 @@
 #endif
 #endif
 
-
-/* Support passing function parameters in registers. For this, the
- * CONFIG_REGPARM macro has to be set to the maximal number of registers
- * allowed. Some functions have intentionally received a regparm lower than
- * their parameter count, it is in order to avoid register clobbering where
- * they are called.
- */
-#ifndef REGPRM1
-#if CONFIG_REGPARM >= 1 && __GNUC__ >= 3
-#define REGPRM1	__attribute__((regparm(1)))
-#else
-#define REGPRM1
-#endif
-#endif
-
-#ifndef REGPRM2
-#if CONFIG_REGPARM >= 2 && __GNUC__ >= 3
-#define REGPRM2	__attribute__((regparm(2)))
-#else
-#define REGPRM2 REGPRM1
-#endif
-#endif
-
-#ifndef REGPRM3
-#if CONFIG_REGPARM >= 3 && __GNUC__ >= 3
-#define REGPRM3	__attribute__((regparm(3)))
-#else
-#define REGPRM3 REGPRM2
-#endif
-#endif
-
-
 /* By default, gcc does not inline large chunks of code, but we want it to
  * respect our choices.
  */

--- a/compiler.h
+++ b/compiler.h
@@ -78,4 +78,24 @@
 #endif
 
 
+/* sets alignment for current field or variable */
+#ifndef ALIGNED
+#define ALIGNED(x) __attribute__((aligned(x)))
+#endif
+
+/* add a mandatory alignment for next fields in a structure */
+#ifndef ALWAYS_ALIGN
+#define ALWAYS_ALIGN(x)  union { } ALIGNED(x)
+#endif
+
+/* add an optional alignment for next fields in a structure, only for archs
+ * which do not support unaligned accesses.
+ */
+#ifndef MAYBE_ALIGN
+#define MAYBE_ALIGN(x)  union { } ALIGNED(x)
+#else
+#define MAYBE_ALIGN(x)
+#endif
+
+
 #endif /* _EBTREE_COMPILER_H */

--- a/eb32tree.c
+++ b/eb32tree.c
@@ -28,22 +28,22 @@
 
 #include "eb32tree.h"
 
-REGPRM2 struct eb32_node *eb32_insert(struct eb_root *root, struct eb32_node *new)
+struct eb32_node *eb32_insert(struct eb_root *root, struct eb32_node *new)
 {
 	return __eb32_insert(root, new);
 }
 
-REGPRM2 struct eb32_node *eb32i_insert(struct eb_root *root, struct eb32_node *new)
+struct eb32_node *eb32i_insert(struct eb_root *root, struct eb32_node *new)
 {
 	return __eb32i_insert(root, new);
 }
 
-REGPRM2 struct eb32_node *eb32_lookup(struct eb_root *root, u32 x)
+struct eb32_node *eb32_lookup(struct eb_root *root, u32 x)
 {
 	return __eb32_lookup(root, x);
 }
 
-REGPRM2 struct eb32_node *eb32i_lookup(struct eb_root *root, s32 x)
+struct eb32_node *eb32i_lookup(struct eb_root *root, s32 x)
 {
 	return __eb32i_lookup(root, x);
 }
@@ -52,7 +52,7 @@ REGPRM2 struct eb32_node *eb32i_lookup(struct eb_root *root, s32 x)
  * Find the last occurrence of the highest key in the tree <root>, which is
  * equal to or less than <x>. NULL is returned is no key matches.
  */
-REGPRM2 struct eb32_node *eb32_lookup_le(struct eb_root *root, u32 x)
+struct eb32_node *eb32_lookup_le(struct eb_root *root, u32 x)
 {
 	struct eb32_node *node;
 	eb_troot_t *troot;
@@ -140,7 +140,7 @@ REGPRM2 struct eb32_node *eb32_lookup_le(struct eb_root *root, u32 x)
  * Find the first occurrence of the lowest key in the tree <root>, which is
  * equal to or greater than <x>. NULL is returned is no key matches.
  */
-REGPRM2 struct eb32_node *eb32_lookup_ge(struct eb_root *root, u32 x)
+struct eb32_node *eb32_lookup_ge(struct eb_root *root, u32 x)
 {
 	struct eb32_node *node;
 	eb_troot_t *troot;

--- a/eb32tree.h
+++ b/eb32tree.h
@@ -116,12 +116,12 @@ static inline void eb32_delete(struct eb32_node *eb32)
  * The following functions are not inlined by default. They are declared
  * in eb32tree.c, which simply relies on their inline version.
  */
-REGPRM2 struct eb32_node *eb32_lookup(struct eb_root *root, u32 x);
-REGPRM2 struct eb32_node *eb32i_lookup(struct eb_root *root, s32 x);
-REGPRM2 struct eb32_node *eb32_lookup_le(struct eb_root *root, u32 x);
-REGPRM2 struct eb32_node *eb32_lookup_ge(struct eb_root *root, u32 x);
-REGPRM2 struct eb32_node *eb32_insert(struct eb_root *root, struct eb32_node *new);
-REGPRM2 struct eb32_node *eb32i_insert(struct eb_root *root, struct eb32_node *new);
+struct eb32_node *eb32_lookup(struct eb_root *root, u32 x);
+struct eb32_node *eb32i_lookup(struct eb_root *root, s32 x);
+struct eb32_node *eb32_lookup_le(struct eb_root *root, u32 x);
+struct eb32_node *eb32_lookup_ge(struct eb_root *root, u32 x);
+struct eb32_node *eb32_insert(struct eb_root *root, struct eb32_node *new);
+struct eb32_node *eb32i_insert(struct eb_root *root, struct eb32_node *new);
 
 /*
  * The following functions are less likely to be used directly, because their

--- a/eb32tree.h
+++ b/eb32tree.h
@@ -47,8 +47,9 @@ typedef   signed int s32;
  */
 struct eb32_node {
 	struct eb_node node; /* the tree node, must be at the beginning */
+	MAYBE_ALIGN(sizeof(u32));
 	u32 key;
-};
+} ALIGNED(sizeof(void*));
 
 /*
  * Exported functions and macros.

--- a/eb64tree.c
+++ b/eb64tree.c
@@ -28,22 +28,22 @@
 
 #include "eb64tree.h"
 
-REGPRM2 struct eb64_node *eb64_insert(struct eb_root *root, struct eb64_node *new)
+struct eb64_node *eb64_insert(struct eb_root *root, struct eb64_node *new)
 {
 	return __eb64_insert(root, new);
 }
 
-REGPRM2 struct eb64_node *eb64i_insert(struct eb_root *root, struct eb64_node *new)
+struct eb64_node *eb64i_insert(struct eb_root *root, struct eb64_node *new)
 {
 	return __eb64i_insert(root, new);
 }
 
-REGPRM2 struct eb64_node *eb64_lookup(struct eb_root *root, u64 x)
+struct eb64_node *eb64_lookup(struct eb_root *root, u64 x)
 {
 	return __eb64_lookup(root, x);
 }
 
-REGPRM2 struct eb64_node *eb64i_lookup(struct eb_root *root, s64 x)
+struct eb64_node *eb64i_lookup(struct eb_root *root, s64 x)
 {
 	return __eb64i_lookup(root, x);
 }
@@ -52,7 +52,7 @@ REGPRM2 struct eb64_node *eb64i_lookup(struct eb_root *root, s64 x)
  * Find the last occurrence of the highest key in the tree <root>, which is
  * equal to or less than <x>. NULL is returned is no key matches.
  */
-REGPRM2 struct eb64_node *eb64_lookup_le(struct eb_root *root, u64 x)
+struct eb64_node *eb64_lookup_le(struct eb_root *root, u64 x)
 {
 	struct eb64_node *node;
 	eb_troot_t *troot;
@@ -140,7 +140,7 @@ REGPRM2 struct eb64_node *eb64_lookup_le(struct eb_root *root, u64 x)
  * Find the first occurrence of the lowest key in the tree <root>, which is
  * equal to or greater than <x>. NULL is returned is no key matches.
  */
-REGPRM2 struct eb64_node *eb64_lookup_ge(struct eb_root *root, u64 x)
+struct eb64_node *eb64_lookup_ge(struct eb_root *root, u64 x)
 {
 	struct eb64_node *node;
 	eb_troot_t *troot;

--- a/eb64tree.h
+++ b/eb64tree.h
@@ -376,17 +376,21 @@ __eb64_insert(struct eb_root *root, struct eb64_node *new) {
 
 		/* walk down */
 		root = &old->node.branches;
-#if BITS_PER_LONG >= 64
-		side = (newkey >> old_node_bit) & EB_NODE_BRANCH_MASK;
-#else
-		side = newkey;
-		side >>= old_node_bit;
-		if (old_node_bit >= 32) {
-			side = newkey >> 32;
-			side >>= old_node_bit & 0x1F;
+
+		if (sizeof(long) >= 8) {
+			side = newkey >> old_node_bit;
+		} else {
+			/* note: provides the best code on low-register count archs
+			 * such as i386.
+			 */
+			side = newkey;
+			side >>= old_node_bit;
+			if (old_node_bit >= 32) {
+				side = newkey >> 32;
+				side >>= old_node_bit & 0x1F;
+			}
 		}
 		side &= EB_NODE_BRANCH_MASK;
-#endif
 		troot = root->b[side];
 	}
 
@@ -554,17 +558,21 @@ __eb64i_insert(struct eb_root *root, struct eb64_node *new) {
 
 		/* walk down */
 		root = &old->node.branches;
-#if BITS_PER_LONG >= 64
-		side = (newkey >> old_node_bit) & EB_NODE_BRANCH_MASK;
-#else
-		side = newkey;
-		side >>= old_node_bit;
-		if (old_node_bit >= 32) {
-			side = newkey >> 32;
-			side >>= old_node_bit & 0x1F;
+
+		if (sizeof(long) >= 8) {
+			side = newkey >> old_node_bit;
+		} else {
+			/* note: provides the best code on low-register count archs
+			 * such as i386.
+			 */
+			side = newkey;
+			side >>= old_node_bit;
+			if (old_node_bit >= 32) {
+				side = newkey >> 32;
+				side >>= old_node_bit & 0x1F;
+			}
 		}
 		side &= EB_NODE_BRANCH_MASK;
-#endif
 		troot = root->b[side];
 	}
 

--- a/eb64tree.h
+++ b/eb64tree.h
@@ -44,11 +44,16 @@ typedef   signed long long s64;
  * eb_node so that it can be cast into an eb_node. We could also have put some
  * sort of transparent union here to reduce the indirection level, but the fact
  * is, the end user is not meant to manipulate internals, so this is pointless.
+ * In case sizeof(void*)>=sizeof(u64), we know there will be some padding after
+ * the key if it's unaligned. In this case we force the alignment on void* so
+ * that we prefer to have the padding before for more efficient accesses.
  */
 struct eb64_node {
 	struct eb_node node; /* the tree node, must be at the beginning */
+	MAYBE_ALIGN(sizeof(u64));
+	ALWAYS_ALIGN(sizeof(void*));
 	u64 key;
-};
+} ALIGNED(sizeof(void*));
 
 /*
  * Exported functions and macros.

--- a/eb64tree.h
+++ b/eb64tree.h
@@ -116,12 +116,12 @@ static inline void eb64_delete(struct eb64_node *eb64)
  * The following functions are not inlined by default. They are declared
  * in eb64tree.c, which simply relies on their inline version.
  */
-REGPRM2 struct eb64_node *eb64_lookup(struct eb_root *root, u64 x);
-REGPRM2 struct eb64_node *eb64i_lookup(struct eb_root *root, s64 x);
-REGPRM2 struct eb64_node *eb64_lookup_le(struct eb_root *root, u64 x);
-REGPRM2 struct eb64_node *eb64_lookup_ge(struct eb_root *root, u64 x);
-REGPRM2 struct eb64_node *eb64_insert(struct eb_root *root, struct eb64_node *new);
-REGPRM2 struct eb64_node *eb64i_insert(struct eb_root *root, struct eb64_node *new);
+struct eb64_node *eb64_lookup(struct eb_root *root, u64 x);
+struct eb64_node *eb64i_lookup(struct eb_root *root, s64 x);
+struct eb64_node *eb64_lookup_le(struct eb_root *root, u64 x);
+struct eb64_node *eb64_lookup_ge(struct eb_root *root, u64 x);
+struct eb64_node *eb64_insert(struct eb_root *root, struct eb64_node *new);
+struct eb64_node *eb64i_insert(struct eb_root *root, struct eb64_node *new);
 
 /*
  * The following functions are less likely to be used directly, because their

--- a/ebimtree.c
+++ b/ebimtree.c
@@ -32,7 +32,7 @@
 /* Find the first occurence of a key of <len> bytes in the tree <root>.
  * If none can be found, return NULL.
  */
-REGPRM3 struct ebpt_node *
+struct ebpt_node *
 ebim_lookup(struct eb_root *root, const void *x, unsigned int len)
 {
 	return __ebim_lookup(root, x, len);
@@ -43,7 +43,7 @@ ebim_lookup(struct eb_root *root, const void *x, unsigned int len)
  * If root->b[EB_RGHT]==1, the tree may only contain unique keys. The
  * len is specified in bytes.
  */
-REGPRM3 struct ebpt_node *
+struct ebpt_node *
 ebim_insert(struct eb_root *root, struct ebpt_node *new, unsigned int len)
 {
 	return __ebim_insert(root, new, len);

--- a/ebimtree.h
+++ b/ebimtree.h
@@ -38,8 +38,8 @@
 /* The following functions are not inlined by default. They are declared
  * in ebimtree.c, which simply relies on their inline version.
  */
-REGPRM3 struct ebpt_node *ebim_lookup(struct eb_root *root, const void *x, unsigned int len);
-REGPRM3 struct ebpt_node *ebim_insert(struct eb_root *root, struct ebpt_node *new, unsigned int len);
+struct ebpt_node *ebim_lookup(struct eb_root *root, const void *x, unsigned int len);
+struct ebpt_node *ebim_insert(struct eb_root *root, struct ebpt_node *new, unsigned int len);
 
 /* Find the first occurence of a key of a least <len> bytes matching <x> in the
  * tree <root>. The caller is responsible for ensuring that <len> will not exceed

--- a/ebistree.c
+++ b/ebistree.c
@@ -32,7 +32,7 @@
  * It's the caller's reponsibility to use this function only on trees which
  * only contain zero-terminated strings. If none can be found, return NULL.
  */
-REGPRM2 struct ebpt_node *ebis_lookup(struct eb_root *root, const char *x)
+struct ebpt_node *ebis_lookup(struct eb_root *root, const char *x)
 {
 	return __ebis_lookup(root, x);
 }
@@ -42,7 +42,7 @@ REGPRM2 struct ebpt_node *ebis_lookup(struct eb_root *root, const char *x)
  * returned. If root->b[EB_RGHT]==1, the tree may only contain unique keys. The
  * caller is responsible for properly terminating the key with a zero.
  */
-REGPRM2 struct ebpt_node *ebis_insert(struct eb_root *root, struct ebpt_node *new)
+struct ebpt_node *ebis_insert(struct eb_root *root, struct ebpt_node *new)
 {
 	return __ebis_insert(root, new);
 }

--- a/ebistree.h
+++ b/ebistree.h
@@ -41,8 +41,8 @@
 /* The following functions are not inlined by default. They are declared
  * in ebistree.c, which simply relies on their inline version.
  */
-REGPRM2 struct ebpt_node *ebis_lookup(struct eb_root *root, const char *x);
-REGPRM2 struct ebpt_node *ebis_insert(struct eb_root *root, struct ebpt_node *new);
+struct ebpt_node *ebis_lookup(struct eb_root *root, const char *x);
+struct ebpt_node *ebis_insert(struct eb_root *root, struct ebpt_node *new);
 
 /* Find the first occurence of a length <len> string <x> in the tree <root>.
  * It's the caller's reponsibility to use this function only on trees which

--- a/ebmbtree.c
+++ b/ebmbtree.c
@@ -31,7 +31,7 @@
 /* Find the first occurence of a key of <len> bytes in the tree <root>.
  * If none can be found, return NULL.
  */
-REGPRM3 struct ebmb_node *
+struct ebmb_node *
 ebmb_lookup(struct eb_root *root, const void *x, unsigned int len)
 {
 	return __ebmb_lookup(root, x, len);
@@ -42,7 +42,7 @@ ebmb_lookup(struct eb_root *root, const void *x, unsigned int len)
  * If root->b[EB_RGHT]==1, the tree may only contain unique keys. The
  * len is specified in bytes.
  */
-REGPRM3 struct ebmb_node *
+struct ebmb_node *
 ebmb_insert(struct eb_root *root, struct ebmb_node *new, unsigned int len)
 {
 	return __ebmb_insert(root, new, len);
@@ -52,7 +52,7 @@ ebmb_insert(struct eb_root *root, struct ebmb_node *new, unsigned int len)
  * tree <root>. It's the caller's responsibility to ensure that key <x> is at
  * least as long as the keys in the tree. If none can be found, return NULL.
  */
-REGPRM2 struct ebmb_node *
+struct ebmb_node *
 ebmb_lookup_longest(struct eb_root *root, const void *x)
 {
 	return __ebmb_lookup_longest(root, x);
@@ -61,7 +61,7 @@ ebmb_lookup_longest(struct eb_root *root, const void *x)
 /* Find the first occurence of a prefix matching a key <x> of <pfx> BITS in the
  * tree <root>. If none can be found, return NULL.
  */
-REGPRM3 struct ebmb_node *
+struct ebmb_node *
 ebmb_lookup_prefix(struct eb_root *root, const void *x, unsigned int pfx)
 {
 	return __ebmb_lookup_prefix(root, x, pfx);
@@ -76,7 +76,7 @@ ebmb_lookup_prefix(struct eb_root *root, const void *x, unsigned int pfx)
  * If root->b[EB_RGHT]==1, the tree may only contain unique keys. The
  * len is specified in bytes.
  */
-REGPRM3 struct ebmb_node *
+struct ebmb_node *
 ebmb_insert_prefix(struct eb_root *root, struct ebmb_node *new, unsigned int len)
 {
 	return __ebmb_insert_prefix(root, new, len);

--- a/ebmbtree.h
+++ b/ebmbtree.h
@@ -42,11 +42,16 @@
  * is, the end user is not meant to manipulate internals, so this is pointless.
  * The 'node.bit' value here works differently from scalar types, as it contains
  * the number of identical bits between the two branches.
+ * Note that we take a great care of making sure the key is located exactly at
+ * the end of the struct even if that involves holes before it, so that it
+ * always aliases any external key a user would append after. This is why the
+ * key uses the same alignment as the struct.
  */
 struct ebmb_node {
 	struct eb_node node; /* the tree node, must be at the beginning */
+	ALWAYS_ALIGN(sizeof(void*));
 	unsigned char key[0]; /* the key, its size depends on the application */
-};
+} ALIGNED(sizeof(void*));
 
 /*
  * Exported functions and macros.

--- a/ebmbtree.h
+++ b/ebmbtree.h
@@ -113,11 +113,11 @@ static forceinline void ebmb_delete(struct ebmb_node *ebmb)
 /* The following functions are not inlined by default. They are declared
  * in ebmbtree.c, which simply relies on their inline version.
  */
-REGPRM3 struct ebmb_node *ebmb_lookup(struct eb_root *root, const void *x, unsigned int len);
-REGPRM3 struct ebmb_node *ebmb_insert(struct eb_root *root, struct ebmb_node *new, unsigned int len);
-REGPRM2 struct ebmb_node *ebmb_lookup_longest(struct eb_root *root, const void *x);
-REGPRM3 struct ebmb_node *ebmb_lookup_prefix(struct eb_root *root, const void *x, unsigned int pfx);
-REGPRM3 struct ebmb_node *ebmb_insert_prefix(struct eb_root *root, struct ebmb_node *new, unsigned int len);
+struct ebmb_node *ebmb_lookup(struct eb_root *root, const void *x, unsigned int len);
+struct ebmb_node *ebmb_insert(struct eb_root *root, struct ebmb_node *new, unsigned int len);
+struct ebmb_node *ebmb_lookup_longest(struct eb_root *root, const void *x);
+struct ebmb_node *ebmb_lookup_prefix(struct eb_root *root, const void *x, unsigned int pfx);
+struct ebmb_node *ebmb_insert_prefix(struct eb_root *root, struct ebmb_node *new, unsigned int len);
 
 /* The following functions are less likely to be used directly, because their
  * code is larger. The non-inlined version is preferred.

--- a/ebpttree.h
+++ b/ebpttree.h
@@ -50,11 +50,14 @@ typedef PTR_INT_TYPE ptr_t;
  * sort of transparent union here to reduce the indirection level, but the fact
  * is, the end user is not meant to manipulate internals, so this is pointless.
  * Internally, it is automatically cast as an eb32_node or eb64_node.
- */
+ * We always align the key since the struct itself will be padded to the same
+ * size anyway.
+  */
 struct ebpt_node {
 	struct eb_node node; /* the tree node, must be at the beginning */
+	ALWAYS_ALIGN(sizeof(void*));
 	void *key;
-};
+} ALIGNED(sizeof(void*));
 
 /*
  * Exported functions and macros.

--- a/ebsttree.c
+++ b/ebsttree.c
@@ -32,7 +32,7 @@
  * It's the caller's reponsibility to use this function only on trees which
  * only contain zero-terminated strings. If none can be found, return NULL.
  */
-REGPRM2 struct ebmb_node *ebst_lookup(struct eb_root *root, const char *x)
+struct ebmb_node *ebst_lookup(struct eb_root *root, const char *x)
 {
 	return __ebst_lookup(root, x);
 }
@@ -42,7 +42,7 @@ REGPRM2 struct ebmb_node *ebst_lookup(struct eb_root *root, const char *x)
  * returned. If root->b[EB_RGHT]==1, the tree may only contain unique keys. The
  * caller is responsible for properly terminating the key with a zero.
  */
-REGPRM2 struct ebmb_node *ebst_insert(struct eb_root *root, struct ebmb_node *new)
+struct ebmb_node *ebst_insert(struct eb_root *root, struct ebmb_node *new)
 {
 	return __ebst_insert(root, new);
 }

--- a/ebsttree.h
+++ b/ebsttree.h
@@ -35,8 +35,8 @@
 /* The following functions are not inlined by default. They are declared
  * in ebsttree.c, which simply relies on their inline version.
  */
-REGPRM2 struct ebmb_node *ebst_lookup(struct eb_root *root, const char *x);
-REGPRM2 struct ebmb_node *ebst_insert(struct eb_root *root, struct ebmb_node *new);
+struct ebmb_node *ebst_lookup(struct eb_root *root, const char *x);
+struct ebmb_node *ebst_insert(struct eb_root *root, struct ebmb_node *new);
 
 /* Find the first occurence of a length <len> string <x> in the tree <root>.
  * It's the caller's reponsibility to use this function only on trees which

--- a/ebtree.c
+++ b/ebtree.c
@@ -32,7 +32,7 @@ void eb_delete(struct eb_node *node)
 }
 
 /* used by insertion primitives */
-REGPRM1 struct eb_node *eb_insert_dup(struct eb_node *sub, struct eb_node *new)
+struct eb_node *eb_insert_dup(struct eb_node *sub, struct eb_node *new)
 {
 	return __eb_insert_dup(sub, new);
 }

--- a/ebtree.h
+++ b/ebtree.h
@@ -910,7 +910,7 @@ static forceinline int get_bit(const unsigned char *a, unsigned int pos)
 
 /* These functions are declared in ebtree.c */
 void eb_delete(struct eb_node *node);
-REGPRM1 struct eb_node *eb_insert_dup(struct eb_node *sub, struct eb_node *new);
+struct eb_node *eb_insert_dup(struct eb_node *sub, struct eb_node *new);
 
 #endif /* _EB_TREE_H */
 

--- a/ebtree.h
+++ b/ebtree.h
@@ -376,6 +376,8 @@ struct eb_root {
  * and one for the node, which remains unused in the very first node inserted
  * into the tree. This structure is 20 bytes per node on 32-bit machines. Do
  * not change the order, benchmarks have shown that it's optimal this way.
+ * Note: be careful about this struct's alignment if it gets included into
+ * another struct and some atomic ops are expected on the keys or the node.
  */
 struct eb_node {
 	struct eb_root branches; /* branches, must be at the beginning */


### PR DESCRIPTION
Hey Willy,

Here's a port of HAProxy's ebtree build fixes. I haven't done extensive performance testing on each commit,
but here's a run before/after the changes, using testfunc on 10000000 nodes.
Let me know what you think.

```
Before changes

Allocated 10000000 nodes of 48 bytes = 480000000 total
Times in CPU cycles for 10000000 ops, for 1, and for 1/log(#nodes) :
  Init:     455902016 45.6  2.7
  Insert:  28565275074 2856.5 166.9
  Del+Ins: 1693441902 169.3  9.9 (last node only -> tree full)
  Lookup:  31705368340 3170.5 185.2
  Delete:  3264520262 326.5 19.1

Allocated 10000000 nodes of 48 bytes = 480000000 total
Times in CPU cycles for 10000000 ops, for 1, and for 1/log(#nodes) :
  Init:     464608024 46.5  2.7
  Insert:  27809759250 2781.0 162.5
  Del+Ins: 1598246596 159.8  9.3 (last node only -> tree full)
  Lookup:  31802819706 3180.3 185.8
  Delete:  3222827194 322.3 18.8

Allocated 10000000 nodes of 48 bytes = 480000000 total
Times in CPU cycles for 10000000 ops, for 1, and for 1/log(#nodes) :
  Init:     441687464 44.2  2.6
  Insert:  29656276210 2965.6 173.2
  Del+Ins: 1592009870 159.2  9.3 (last node only -> tree full)
  Lookup:  33235267756 3323.5 194.2
  Delete:  3410673430 341.1 19.9
  
After changes

Allocated 10000000 nodes of 48 bytes = 480000000 total
Times in CPU cycles for 10000000 ops, for 1, and for 1/log(#nodes) :
  Init:     468563630 46.9  2.7
  Insert:  27150437044 2715.0 158.6
  Del+Ins: 1533149470 153.3  9.0 (last node only -> tree full)
  Lookup:  33070370928 3307.0 193.2
  Delete:  3134969826 313.5 18.3

Allocated 10000000 nodes of 48 bytes = 480000000 total
Times in CPU cycles for 10000000 ops, for 1, and for 1/log(#nodes) :
  Init:     480583766 48.1  2.8
  Insert:  26900943606 2690.1 157.1
  Del+Ins: 1560172660 156.0  9.1 (last node only -> tree full)
  Lookup:  29965339110 2996.5 175.1
  Delete:  3159664482 316.0 18.5

Allocated 10000000 nodes of 48 bytes = 480000000 total
Times in CPU cycles for 10000000 ops, for 1, and for 1/log(#nodes) :
  Init:     464727978 46.5  2.7
  Insert:  25892779528 2589.3 151.3
  Del+Ins: 1556361300 155.6  9.1 (last node only -> tree full)
  Lookup:  29142198092 2914.2 170.2
  Delete:  3121906522 312.2 18.2
```